### PR TITLE
CLIから複数のタスク名を渡せるようにした

### DIFF
--- a/bin/pon
+++ b/bin/pon
@@ -13,7 +13,7 @@ const pon = require('../lib')
 
 program
   .version(pkg[ 'version' ])
-  .usage('[options] <name> ')
+  .usage('[options] <name ...> ')
   .description(pkg[ 'description' ])
   .option('-l, --list [list]', 'List available tasks')
 program.parse(process.argv)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,7 +12,7 @@ const ponfile = require('ponfile')
 function cli (name, options) {
   let args = argx(arguments)
   options = args.pop('object') || {}
-  name = args.shift('string')
+  let names = args.remain()
   let {
     cwd = process.cwd(),
     list = false
@@ -23,14 +23,19 @@ function cli (name, options) {
       let pattern = typeof list === 'string' ? list : null
       return cli.list(runner.tasks, { pattern })
     }
-    if (name) {
-      return Promise.resolve(runner.run(name)).then((results) => {
-        let isEmpty = Object.keys(results).length === 0
-        if (isEmpty) {
-          console.warn(`No task found for name: "${name}"`)
-        }
-        return results
-      })
+    if (names && names.length > 0) {
+      let results = []
+      for (let name of names) {
+        let result = yield Promise.resolve(runner.run(name)).then((result) => {
+          let isEmpty = Object.keys(result).length === 0
+          if (isEmpty) {
+            console.warn(`No task found for name: "${name}"`)
+          }
+          return result
+        })
+        results.push(result)
+      }
+      return results
     }
     let hasDefault = !!runner.tasks.default
     if (hasDefault) {

--- a/misc/mock/mock-project-01/Ponfile.js
+++ b/misc/mock/mock-project-01/Ponfile.js
@@ -6,6 +6,12 @@ const fs = require('fs')
 module.exports = ponRunner({
   writeFoo () {
     fs.writeFileSync(`${__dirname}/foo.txt`, 'This is foo')
+  },
+  a () {
+    console.log('This is A')
+  },
+  b () {
+    console.log('This is B')
   }
 }).bind()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pon-cli",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "CLI for pon",
   "main": "lib",
   "bin": {
@@ -28,7 +28,7 @@
     "argx": "^3.0.2",
     "co": "^4.6.0",
     "commander": "^2.9.0",
-    "ponfile": "^3.0.1"
+    "ponfile": "^3.0.2"
   },
   "devDependencies": {
     "ababel": "^2.0.1",
@@ -38,12 +38,12 @@
     "ape-releasing": "^4.0.4",
     "ape-tasking": "^4.0.9",
     "ape-tmpl": "^5.0.20",
-    "ape-updating": "^4.1.0",
+    "ape-updating": "^4.1.1",
     "coz": "^6.0.20",
     "filecopy": "^3.0.1",
     "injectmock": "^2.0.0",
     "pon-assets": "^1.1.5",
-    "pon-runner": "^2.0.1",
+    "pon-runner": "^2.0.2",
     "sg-templates": "^1.4.4",
     "sugos-travis": "^2.0.7"
   },

--- a/signature.json
+++ b/signature.json
@@ -4,6 +4,7 @@
   "args": [
     {
       "name": "name",
+      "multiple": true,
       "desc": "Task name (or name pattern) to run"
     }
   ],


### PR DESCRIPTION
CLIの引数に複数のタスク名を渡すと順次実行するようにした。

```bash
$ pon clean build
```